### PR TITLE
EXC_BAD_ACCESS caused by non deterministic value

### DIFF
--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -1090,9 +1090,9 @@ static OSStatus CopyIdentityWithLabel(char *label,
 #if CURL_BUILD_IOS
           common_name = SecCertificateCopySubjectSummary(cert);
 #elif CURL_BUILD_MAC_10_7
-          SecCertificateCopyCommonName(cert, &common_name);
+          OSStatus copy_status = SecCertificateCopyCommonName(cert, &common_name);
 #endif
-          if(CFStringCompare(common_name, label_cf, 0) == kCFCompareEqualTo) {
+          if(copy_status == errSecSuccess && CFStringCompare(common_name, label_cf, 0) == kCFCompareEqualTo) {
             CFRelease(cert);
             CFRelease(common_name);
             CFRetain(identity);


### PR DESCRIPTION
We have following code in Curl.
...
 SecCertificateCopyCommonName(cert, &common_name);
#endif
          if(CFStringCompare(common_name, label_cf, 0) == kCFCompareEqualTo)

When the SecCertificateCopyCommonName function fails, it does not have to leave common_name in valid, state. So CFStringCompare is using the invalid result, hence causing EXC_BAD_ACCESS.

Fix is to check return value of the function.